### PR TITLE
Fix #8 and #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+config.yml
+crates.yml

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: PiggyCrates
 main: PiggyCrates\Main
-version: 1.0.1
-api: 3.0.0-ALPHA11
+version: 1.1.0
+api: 3.0.0-ALPHA12
 load: POSTWORLD
 author: DaPigGuy
 permissions:

--- a/resources/crates.yml
+++ b/resources/crates.yml
@@ -15,80 +15,80 @@ crates:
 # Still confused? Refer to our example configuration: https://github.com/DaPigGuy/PiggyCrates/wiki/Example-Configuration
   common:
     drops:
-      17:
-        name: "Oak Wood"
+      - name: "Oak Wood"
+        id: 17
         meta: 0
         amount: 16
-      1:
-        name: "Stone"
+      - name: "Stone"
+        id: 1
         meta: 0
         amount: 16
-      364:
-        name: "Cooked Beef"
+      - name: "Cooked Beef"
+        id: 364
         meta: 0
         amount: 5
     amount: 1
     block: "173:0"
   uncommon:
     drops:
-      263:
-        name: "Coal"
+      - name: "Coal"
+        id: 263
         meta: 0
         amount: 10
-      50:
-        name: "Torch"
+      - name: "Torch"
+        id: 50
         meta: 0
         amount: 16
-      366:
-        name: "Cooked Chicken"
+      - name: "Cooked Chicken"
+        id: 366
         meta: 0
         amount: 16
     amount: 1
     block: "42:0"
   vote:
     drops:
-      265:
-        name: "Iron Ingot"
+      - name: "Iron Ingot"
+        id: 265
         meta: 0
         amount: 10
-      266:
-        name: "Gold Ingot"
+      - name: "Gold Ingot"
+        id: 266
         meta: 0
         amount: 10
-      17:
-        name: "Oak Wood"
+      - name: "Oak Wood"
+        id: 17
         meta: 0
         amount: 64
     amount: 1
     block: "41:0"
   mythic:
     drops:
-      264:
-        name: "Diamond"
+      - name: "Diamond"
+        id: 264
         meta: 0
         amount: 16
-      388:
-        name: "Emerald"
+      - name: "Emerald"
+        id: 388
         meta: 0
         amount: 16
-      322:
-        name: "Golden Apple"
+      - name: "Golden Apple"
+        id: 322
         meta: 0
         amount: 16
     amount: 1
     block: "57:0"
   legendary:
     drops:
-      49:
-        name: "Obsidian"
+      - name: "Obsidian"
+        id: 49
         meta: 0
         amount: 32
-      466:
-        name: "Enchanted Apple"
+      - name: "Enchanted Apple"
+        id: 466
         meta: 0
         amount: 16
-      7:
-        name: "Bedrock"
+      - name: "Bedrock"
+        id: 7
         meta: 0
         amount: 5
     amount: 1

--- a/src/PiggyCrates/EventListener.php
+++ b/src/PiggyCrates/EventListener.php
@@ -114,6 +114,8 @@ class EventListener implements Listener
                         $drops = [$drops];
                     }
                     $list = [];
+                    $items = [];
+                    $dropsReceivable = [];
                     foreach ($drops as $drop) {
                         $values = $this->plugin->getCrateDrops($type)[$drop];
                         $list[] = $values["amount"] . " " . $values["name"];
@@ -131,10 +133,16 @@ class EventListener implements Listener
                             }
                         }
                         $i->setCustomName($values["name"]);
-                        $player->getInventory()->addItem($i);
+                        $dropsReceivable[$drop] = $player->getInventory()->canAddItem($i);
+                        $items[] = $i;
                     }
-                    $player->getInventory()->removeItem($item->setCount(1));
-                    $player->sendTip(TextFormat::GREEN . "You have received " . implode(", ", $list));
+                    if(array_search(false, $dropsReceivable) === false){
+                        $player->getInventory()->removeItem($item->setCount(1));
+                        $player->getInventory()->addItem(...$items);
+                        $player->sendTip(TextFormat::GREEN . "You have received " . implode(", ", $list));
+                    }else{
+                        $player->sendTip(TextFormat::RED ."Please clear your inventory.");
+                    }
                 }
             }
             $event->setCancelled();

--- a/src/PiggyCrates/EventListener.php
+++ b/src/PiggyCrates/EventListener.php
@@ -117,7 +117,7 @@ class EventListener implements Listener
                     foreach ($drops as $drop) {
                         $values = $this->plugin->getCrateDrops($type)[$drop];
                         $list[] = $values["amount"] . " " . $values["name"];
-                        $i = Item::get($drop, $values["meta"], $values["amount"]);
+                        $i = Item::get($values["id"], $values["meta"], $values["amount"]);
                         if (isset($values["enchantments"])) {
                             foreach ($values["enchantments"] as $enchantment => $enchantmentinfo) {
                                 $level = $enchantmentinfo["level"];


### PR DESCRIPTION
This pr moves the item id keys to values in order to fix issue #8.
Additionally it adds checks to prevent create fraud, where one would not receive the drops. #11 

The plugin version was bumped to 1.1.0 due to #8 being **backwards-incompatible** and the api version was updated.