### PR TITLE
Check if player can receive drops #11

### DIFF
--- a/src/PiggyCrates/EventListener.php
+++ b/src/PiggyCrates/EventListener.php
@@ -114,6 +114,8 @@ class EventListener implements Listener
                         $drops = [$drops];
                     }
                     $list = [];
+                    $items = [];
+                    $dropsReceivable = [];
                     foreach ($drops as $drop) {
                         $values = $this->plugin->getCrateDrops($type)[$drop];
                         $list[] = $values["amount"] . " " . $values["name"];
@@ -131,10 +133,16 @@ class EventListener implements Listener
                             }
                         }
                         $i->setCustomName($values["name"]);
-                        $player->getInventory()->addItem($i);
+                        $dropsReceivable[$drop] = $player->getInventory()->canAddItem($i);
+                        $items[] = $i;
                     }
-                    $player->getInventory()->removeItem($item->setCount(1));
-                    $player->sendTip(TextFormat::GREEN . "You have received " . implode(", ", $list));
+                    if(array_search(false, $dropsReceivable) === false){
+                        $player->getInventory()->removeItem($item->setCount(1));
+                        $player->getInventory()->addItem(...$items);
+                        $player->sendTip(TextFormat::GREEN . "You have received " . implode(", ", $list));
+                    }else{
+                        $player->sendTip(TextFormat::RED ."Please clear your inventory.");
+                    }
                 }
             }
             $event->setCancelled();


### PR DESCRIPTION
Before giving the player the item drops the code will now check if the player can receive the drops.
If the player can't receive them, the items won't be handed out and the crate key won't be taken from the player.
Instead the player is asked to clear their inventory.

Related to issue #11 