### PR TITLE
Fix for #9 and #18

### DIFF
--- a/src/PiggyCrates/EventListener.php
+++ b/src/PiggyCrates/EventListener.php
@@ -120,6 +120,7 @@ class EventListener implements Listener
                         $values = $this->plugin->getCrateDrops($type)[$drop];
                         $list[] = $values["amount"] . " " . $values["name"];
                         $i = Item::get($values["id"], $values["meta"], $values["amount"]);
+                        $i->setCustomName($values["name"]);
                         if (isset($values["enchantments"])) {
                             foreach ($values["enchantments"] as $enchantment => $enchantmentinfo) {
                                 $level = $enchantmentinfo["level"];
@@ -132,7 +133,6 @@ class EventListener implements Listener
                                 }
                             }
                         }
-                        $i->setCustomName($values["name"]);
                         $dropsReceivable[$drop] = $player->getInventory()->canAddItem($i);
                         $items[] = $i;
                     }


### PR DESCRIPTION
This PR fixes the issues as mentioned in #9 and #18. <br />
The ` $i->setCustomName($values["name"]) ` was being called after the CustomEnchants were applied leading to the item being CustomEnchanted but with a custom name as  PiggyCustomEnchants lists the enchants using the `setCustomName()`.<br />
So adding the same before the application of Enchants fixes the issue as shown in this PR. 
