### PR TITLE
Added ability to reward commands to players.

### DIFF
--- a/resources/crates.yml
+++ b/resources/crates.yml
@@ -10,23 +10,21 @@ crates:
             #level: 1
           #enchantment2:
             #level: 1
+        #command: say THIS IS AWESOME. (Note: You can use %PLAYER% if you want to add the name of the player.)
     #amount: 1 (amount of drops that can be received from opening crate)
     #block: "173:0" (id:meta; the block under chest to determine crate type)
 # Still confused? Refer to our example configuration: https://github.com/DaPigGuy/PiggyCrates/wiki/Example-Configuration
   common:
     drops:
-      - name: "Oak Wood"
-        id: 17
-        meta: 0
-        amount: 16
-      - name: "Stone"
+      - name: "Command"
         id: 1
         meta: 0
-        amount: 16
-      - name: "Cooked Beef"
-        id: 364
+        amount: 0
+        command: say ALOHA %PLAYER%.
+      - name: "Coal"
+        id: 263
         meta: 0
-        amount: 5
+        amount: 10
     amount: 1
     block: "173:0"
   uncommon:


### PR DESCRIPTION
This PR is tested. <br />
Further as the title suggests the crate can now reward player with a command if the `command:` key is set in the `crates.yml`. The `%PLAYER%` if set would be replaced by the players name and the command would be executed from `console`. It is executed from console because if the player (i.e. the owner of a server) wants to reward the player (i.e. the one using the crate) with a rank e.g. `setgroup %PLAYER% Mystery` then that command needs `op` status or it has to be run from console.