### PR TITLE
Ability to Preview Crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ jobs:
         uses: wei/wget@v1
         with:
           args: -O vendor/Commando.phar https://poggit.pmmp.io/r/67875/Commando_dev-27.phar
+      - name: wget virions, InvMenu
+        uses: wei/wget@v1
+        with:
+          args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/73860/InvMenu_dev-84.phar
       - name: Run PHPStan
         uses: nxtlvlsoftware/pmmp-phpstan-action@3
         with:

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -7,4 +7,6 @@ projects:
     libs:
       - src: CortexPE/Commando/Commando
         version: ^0.5
+      - src: muqsit/InvMenu/InvMenu
+        version: ^3.1
 ...

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PiggyCrates is a simple and customizable crates plugin, supporting an unlimited 
 
 ## Information
 * We do not support any spoons. Anything to do with spoons (Issues or PRs) will be ignored.
-* We are using the following virions: [Commando](https://github.com/CortexPE/Commando).
+* We are using the following virions: [Commando](https://github.com/CortexPE/Commando), [InvMenu](https://github.com/Muqsit/InvMenu).
     * **You MUST use the pre-compiled phar from [Poggit-CI](https://poggit.pmmp.io/ci/DaPigGuy/PiggyCrates/~) instead of GitHub.**
     * If you wish to run it via source, check out [DEVirion](https://github.com/poggit/devirion).
 * Check out our installation guide at [PiggyDocs](https://piggydocs.aericio.net/PiggyCrates.html).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PiggyCrates is a simple and customizable crates plugin, supporting an unlimited 
 
 ## Information
 * We do not support any spoons. Anything to do with spoons (Issues or PRs) will be ignored.
-* We are using the following virions: [Commando](https://github.com/CortexPE/Commando), [InvMenu](https://github.com/Muqsit/InvMenu).
+* We are using the following virions: [Commando](https://github.com/CortexPE/Commando) and [InvMenu](https://github.com/Muqsit/InvMenu).
     * **You MUST use the pre-compiled phar from [Poggit-CI](https://poggit.pmmp.io/ci/DaPigGuy/PiggyCrates/~) instead of GitHub.**
     * If you wish to run it via source, check out [DEVirion](https://github.com/poggit/devirion).
 * Check out our installation guide at [PiggyDocs](https://piggydocs.aericio.net/PiggyCrates.html).

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
     - /source/src
     - phar:///deps/PiggyCustomEnchants.phar/src/
     - phar:///source/vendor/Commando.phar/src/
+    - phar:///source/vendor/InvMenu.phar/src/
   excludes_analyse:
     - source/vendor
   reportUnmatchedIgnoredErrors: false

--- a/src/DaPigGuy/PiggyCrates/EventListener.php
+++ b/src/DaPigGuy/PiggyCrates/EventListener.php
@@ -39,7 +39,7 @@ class EventListener implements Listener
                     $player->sendTip(TextFormat::RED . "Invalid or missing crate type.");
                 } elseif ($tile->getCrateType()->isValidKey($item)) {
                     $tile->openCrate($player, $item);
-                } elseif($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
+                } elseif ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
                     $tile->previewCrate($player);
                 }
                 $event->setCancelled();

--- a/src/DaPigGuy/PiggyCrates/EventListener.php
+++ b/src/DaPigGuy/PiggyCrates/EventListener.php
@@ -39,6 +39,8 @@ class EventListener implements Listener
                     $player->sendTip(TextFormat::RED . "Invalid or missing crate type.");
                 } elseif ($tile->getCrateType()->isValidKey($item)) {
                     $tile->openCrate($player, $item);
+                } elseif($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
+                    $tile->previewCrate($player);
                 }
                 $event->setCancelled();
                 return;

--- a/src/DaPigGuy/PiggyCrates/PiggyCrates.php
+++ b/src/DaPigGuy/PiggyCrates/PiggyCrates.php
@@ -14,9 +14,11 @@ use DaPigGuy\PiggyCrates\tasks\CheckUpdatesTask;
 use DaPigGuy\PiggyCrates\tiles\CrateTile;
 use DaPigGuy\PiggyCustomEnchants\CustomEnchantManager;
 use DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants;
+use muqsit\invmenu\InvMenuHandler;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\enchantment\EnchantmentInstance;
 use pocketmine\item\Item;
+use pocketmine\nbt\tag\StringTag;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\tile\Tile;
@@ -45,6 +47,10 @@ class PiggyCrates extends PluginBase
             return;
         }
 
+        if(!InvMenuHandler::isRegistered()) {
+            InvMenuHandler::register($this);
+        }
+
         self::$instance = $this;
 
         Tile::registerTile(CrateTile::class);
@@ -66,6 +72,7 @@ class PiggyCrates extends PluginBase
                     $enchantment = Enchantment::getEnchantmentByName($enchantmentData["name"]) ?? ((($plugin = $this->getServer()->getPluginManager()->getPlugin("PiggyCustomEnchants")) instanceof PiggyCustomEnchants && $plugin->isEnabled()) ? CustomEnchantManager::getEnchantmentByName($enchantmentData["name"]) : null);
                     if ($enchantment !== null) $item->addEnchantment(new EnchantmentInstance($enchantment, $enchantmentData["level"]));
                 }
+                //if(isset($itemData["command"])) $item->setNamedTagEntry(new StringTag("execute_command", $itemData["command"]));
                 return new CrateItem($item, $itemData["commands"] ?? [], $itemData["chance"] ?? 100);
             }, $crateData["drops"] ?? []), $crateData["amount"], $crateData["commands"] ?? []);
         }

--- a/src/DaPigGuy/PiggyCrates/PiggyCrates.php
+++ b/src/DaPigGuy/PiggyCrates/PiggyCrates.php
@@ -46,7 +46,7 @@ class PiggyCrates extends PluginBase
             return;
         }
 
-        if(!InvMenuHandler::isRegistered()) {
+        if (!InvMenuHandler::isRegistered()) {
             InvMenuHandler::register($this);
         }
 

--- a/src/DaPigGuy/PiggyCrates/PiggyCrates.php
+++ b/src/DaPigGuy/PiggyCrates/PiggyCrates.php
@@ -18,7 +18,6 @@ use muqsit\invmenu\InvMenuHandler;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\enchantment\EnchantmentInstance;
 use pocketmine\item\Item;
-use pocketmine\nbt\tag\StringTag;
 use pocketmine\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\tile\Tile;
@@ -72,7 +71,6 @@ class PiggyCrates extends PluginBase
                     $enchantment = Enchantment::getEnchantmentByName($enchantmentData["name"]) ?? ((($plugin = $this->getServer()->getPluginManager()->getPlugin("PiggyCustomEnchants")) instanceof PiggyCustomEnchants && $plugin->isEnabled()) ? CustomEnchantManager::getEnchantmentByName($enchantmentData["name"]) : null);
                     if ($enchantment !== null) $item->addEnchantment(new EnchantmentInstance($enchantment, $enchantmentData["level"]));
                 }
-                //if(isset($itemData["command"])) $item->setNamedTagEntry(new StringTag("execute_command", $itemData["command"]));
                 return new CrateItem($item, $itemData["commands"] ?? [], $itemData["chance"] ?? 100);
             }, $crateData["drops"] ?? []), $crateData["amount"], $crateData["commands"] ?? []);
         }

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -54,7 +54,7 @@ class RouletteTask extends Task
     public function onRun(int $currentTick): void
     {
         if ($this->preview) {
-            $this->roulette(true);
+            $this->roulette();
             return;
         }
 
@@ -93,7 +93,7 @@ class RouletteTask extends Task
         $this->roulette();
     }
 
-    public function roulette(bool $preview = false): void
+    public function roulette(): void
     {
         $crateType = $this->tile->getCrateType();
         if ($crateType === null) {
@@ -103,7 +103,7 @@ class RouletteTask extends Task
             return;
         }
 
-        if ($preview) $this->currentTick++;
+        if ($this->preview) $this->currentTick++;
 
         if ($this->currentTick % PiggyCrates::$instance->getConfig()->getNested("crates.roulette.speed") === 0) {
             $lastRewards = [];
@@ -114,7 +114,7 @@ class RouletteTask extends Task
             foreach ($this->lastRewards as $slot => $lastReward) {
                 if ($slot !== 9) {
                     $lastRewards[$slot - 1] = $lastReward;
-                    if ($preview) {
+                    if ($this->preview) {
                         $this->menu->getInventory()->setItem($slot - 1, $lastReward->getItem());
                     } else {
                         $this->tile->getInventory()->setItem($slot - 1, $lastReward->getItem());
@@ -123,7 +123,7 @@ class RouletteTask extends Task
             }
 
             $lastRewards[17] = $crateType->getDrop(1)[0];
-            if ($preview) {
+            if ($this->preview) {
                 $this->menu->getInventory()->setItem(17, $lastRewards[17]->getItem());
             } else {
                 $this->tile->getInventory()->setItem(17, $lastRewards[17]->getItem());

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -32,13 +32,11 @@ class RouletteTask extends Task
 
     /** @var bool */
     private $preview = false;
-    /**
-     * @var SharedInvMenu
-     */
+
+    /** @var SharedInvMenu */
     private $menu;
-    /**
-     * @var Player|null
-     */
+
+    /** @var Player|null */
     private $player;
 
     public function __construct(CrateTile $tile, ?Player $player = null, bool $preview = false)

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -7,7 +7,11 @@ namespace DaPigGuy\PiggyCrates\tasks;
 use DaPigGuy\PiggyCrates\crates\CrateItem;
 use DaPigGuy\PiggyCrates\PiggyCrates;
 use DaPigGuy\PiggyCrates\tiles\CrateTile;
+use muqsit\invmenu\inventory\InvMenuInventory;
+use muqsit\invmenu\InvMenu;
+use muqsit\invmenu\SharedInvMenu;
 use pocketmine\command\ConsoleCommandSender;
+use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\scheduler\Task;
 
@@ -26,14 +30,36 @@ class RouletteTask extends Task
     /** @var CrateItem[] */
     private $lastRewards = [];
 
-    public function __construct(CrateTile $tile)
+    /** @var bool */
+    private $preview = false;
+    /**
+     * @var SharedInvMenu
+     */
+    private $menu;
+    /**
+     * @var Player
+     */
+    private $player;
+
+    public function __construct(CrateTile $tile, Player $player = null, $preview = false)
     {
         $this->tile = $tile;
         $this->itemsLeft = $tile->getCrateType() === null ? 0 : $tile->getCrateType()->getDropCount();
+
+        if ($preview) {
+            $this->preview = true;
+            $this->player = $player;
+            $this->setupPreviewMenu();
+        }
     }
 
     public function onRun(int $currentTick): void
     {
+        if ($this->preview) {
+            $this->roulette(true);
+            return;
+        }
+
         if (!$this->tile->getCurrentPlayer() instanceof Player || !$this->tile->getCurrentPlayer()->isOnline() || ($crateType = $this->tile->getCrateType()) === null) {
             $this->tile->closeCrate();
             if (($handler = $this->getHandler()) !== null) $handler->cancel();
@@ -66,6 +92,21 @@ class RouletteTask extends Task
             }
             return;
         }
+        $this->roulette();
+    }
+
+    public function roulette(bool $preview = false): void
+    {
+        $crateType = $this->tile->getCrateType();
+        if ($crateType === null) {
+            if (($handler = $this->getHandler()) !== null) {
+                $handler->cancel();
+            }
+            return;
+        }
+
+        if ($preview) $this->currentTick++;
+
         if ($this->currentTick % PiggyCrates::$instance->getConfig()->getNested("crates.roulette.speed") === 0) {
             $lastRewards = [];
             /**
@@ -75,12 +116,41 @@ class RouletteTask extends Task
             foreach ($this->lastRewards as $slot => $lastReward) {
                 if ($slot !== 9) {
                     $lastRewards[$slot - 1] = $lastReward;
-                    $this->tile->getInventory()->setItem($slot - 1, $lastReward->getItem());
+                    if ($preview) {
+                        $this->menu->getInventory()->setItem($slot - 1, $lastReward->getItem());
+                    } else {
+                        $this->tile->getInventory()->setItem($slot - 1, $lastReward->getItem());
+                    }
                 }
             }
+
             $lastRewards[17] = $crateType->getDrop(1)[0];
-            $this->tile->getInventory()->setItem(17, $lastRewards[17]->getItem());
+            if ($preview) {
+                $this->menu->getInventory()->setItem(17, $lastRewards[17]->getItem());
+            } else {
+                $this->tile->getInventory()->setItem(17, $lastRewards[17]->getItem());
+            }
             $this->lastRewards = $lastRewards;
         }
+    }
+
+    private function setupPreviewMenu(): void
+    {
+        $this->menu = InvMenu::create(InvMenu::TYPE_CHEST);
+        $this->menu->getInventory()->setItem(4, Item::get(Item::END_ROD, 0, 1));
+        $this->menu->getInventory()->setItem(22, Item::get(Item::END_ROD, 0, 1));
+        $this->menu->readonly();
+        $this->menu->setName($this->tile->getName());
+
+        if ($this->player instanceof Player && $this->player->isOnline()) {
+            $this->menu->send($this->player);
+        }
+
+        $this->menu->setInventoryCloseListener(function (Player $player, InvMenuInventory $inventory): bool {
+            if (($handler = $this->getHandler()) !== null) {
+                $handler->cancel();
+            }
+            return true;
+        });
     }
 }

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -37,11 +37,11 @@ class RouletteTask extends Task
      */
     private $menu;
     /**
-     * @var Player
+     * @var Player|null
      */
     private $player;
 
-    public function __construct(CrateTile $tile, Player $player = null, $preview = false)
+    public function __construct(CrateTile $tile, ?Player $player = null, bool $preview = false)
     {
         $this->tile = $tile;
         $this->itemsLeft = $tile->getCrateType() === null ? 0 : $tile->getCrateType()->getDropCount();

--- a/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
+++ b/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
@@ -69,8 +69,7 @@ class CrateTile extends Chest
             case "instant":
                 $this->closeCrate();
                 foreach ($crateType->getDrop($crateType->getDropCount()) as $drop) {
-                    $item = $drop->getItem();
-                    $player->getInventory()->addItem($item);
+                    $player->getInventory()->addItem($drop->getItem());
                     foreach ($drop->getCommands() as $command) {
                         $player->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{PLAYER}", $player->getName(), $command));
                     }

--- a/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
+++ b/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
@@ -69,7 +69,8 @@ class CrateTile extends Chest
             case "instant":
                 $this->closeCrate();
                 foreach ($crateType->getDrop($crateType->getDropCount()) as $drop) {
-                    $player->getInventory()->addItem($drop->getItem());
+                    $item = $drop->getItem();
+                    $player->getInventory()->addItem($item);
                     foreach ($drop->getCommands() as $command) {
                         $player->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{PLAYER}", $player->getName(), $command));
                     }
@@ -101,6 +102,13 @@ class CrateTile extends Chest
         $this->currentPlayer = null;
     }
 
+    public function previewCrate(Player $player): void
+    {
+        if (($crateType = $this->crateType) === null || ($level = $this->getLevel()) === null) return;
+
+        PiggyCrates::$instance->getScheduler()->scheduleRepeatingTask(new RouletteTask($this, $player, true), 1);
+    }
+
     public function close(): void
     {
         foreach ($this->floatingTextParticles as $floatingTextParticle) {
@@ -118,21 +126,6 @@ class CrateTile extends Chest
     public function getCurrentPlayer(): ?Player
     {
         return $this->currentPlayer;
-    }
-
-    protected function readSaveData(CompoundTag $nbt): void
-    {
-        parent::readSaveData($nbt);
-        $this->crateName = $nbt->getString("CrateType");
-        $this->crateType = PiggyCrates::getCrate($this->crateName);
-
-        $this->scheduleUpdate();
-    }
-
-    protected function writeSaveData(CompoundTag $nbt): void
-    {
-        parent::writeSaveData($nbt);
-        $nbt->setString("CrateType", $this->crateName);
     }
 
     public function addAdditionalSpawnData(CompoundTag $nbt): void
@@ -164,5 +157,20 @@ class CrateTile extends Chest
             }
         }
         return !$this->closed;
+    }
+
+    protected function readSaveData(CompoundTag $nbt): void
+    {
+        parent::readSaveData($nbt);
+        $this->crateName = $nbt->getString("CrateType");
+        $this->crateType = PiggyCrates::getCrate($this->crateName);
+
+        $this->scheduleUpdate();
+    }
+
+    protected function writeSaveData(CompoundTag $nbt): void
+    {
+        parent::writeSaveData($nbt);
+        $nbt->setString("CrateType", $this->crateName);
     }
 }


### PR DESCRIPTION
<!-- Failure to complete the required fields will result in the pull request being closed. -->
Please make sure your issue complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title (i.e "Fix Crate items don't appear in inventory")

### What does the PR change?
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
-->
This PR aims to add the ability to preview the items within a crate. The RouletteTask has been modified to loop through all possible drops endlessly without giving the player an item, until the player closes the menu.  

### Testing Environment
<!-- Use `/version` for PMMP version -->
* PocketMine-MP: 3.11.5
* PHP: 7.2
* Server OS: Windows 10

<!--- Provide any extra information below  -->
### Extra Information
The InvMenu virion is used.