### PR TITLE
Update to InvMenu v4.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,11 @@ jobs:
       - name: wget virions, Commando
         uses: wei/wget@v1
         with:
-          args: -O vendor/Commando.phar https://poggit.pmmp.io/r/89644/Commando_dev-13.phar
+          args: -O vendor/Commando.phar https://poggit.pmmp.io/r/120160/Commando_dev-24.phar
       - name: wget virions, InvMenu
         uses: wei/wget@v1
         with:
-          args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/94959/InvMenu_dev-105.phar
+          args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/131080/InvMenu_dev-153.phar
       - name: Run PHPStan
         uses: paroxity/pmmp-phpstan-action@3.22.1
         with:

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -9,7 +9,7 @@ projects:
       - src: ParoxityTeam/Commando/Commando
         version: ^2.1.0
       - src: muqsit/InvMenu/InvMenu
-        version: ^3.1.1
+        version: ^4.1.1
     lint:
       phpstan: false
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -6,8 +6,8 @@ projects:
     path: ""
     icon: "resources/img/PiggyCrates.gif"
     libs:
-      - src: ParoxityTeam/Commando/Commando
-        version: ^2.1.0
+      - src: Paroxity/Commando/Commando
+        version: ^2.1.2
       - src: muqsit/InvMenu/InvMenu
         version: ^4.1.1
     lint:

--- a/src/DaPigGuy/PiggyCrates/PiggyCrates.php
+++ b/src/DaPigGuy/PiggyCrates/PiggyCrates.php
@@ -61,6 +61,12 @@ class PiggyCrates extends PluginBase
             }
         }
 
+        if ($this->getServer()->getPluginManager()->getPlugin("InvCrashFix") === null) {
+            $this->getLogger()->info("Missing InvCrashFix plugin. Download here: https://poggit.pmmp.io/r/94956/InvCrashFix_dev-3.phar");
+            $this->getServer()->getPluginManager()->disablePlugin($this);
+            return;
+        }
+
         if (!InvMenuHandler::isRegistered()) {
             InvMenuHandler::register($this);
         }

--- a/src/DaPigGuy/PiggyCrates/PiggyCrates.php
+++ b/src/DaPigGuy/PiggyCrates/PiggyCrates.php
@@ -62,7 +62,7 @@ class PiggyCrates extends PluginBase
         }
 
         if ($this->getServer()->getPluginManager()->getPlugin("InvCrashFix") === null) {
-            $this->getLogger()->info("Missing InvCrashFix plugin. Download here: https://poggit.pmmp.io/r/94956/InvCrashFix_dev-3.phar");
+            $this->getLogger()->error("Missing InvCrashFix plugin. Download here: https://poggit.pmmp.io/r/94956/InvCrashFix_dev-3.phar");
             $this->getServer()->getPluginManager()->disablePlugin($this);
             return;
         }

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -1,4 +1,3 @@
-
 <?php
 
 declare(strict_types=1);

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -53,7 +53,7 @@ class RouletteTask extends Task
         $this->menu->setInventoryCloseListener(function (Player $player): void {
             if ($this->itemsLeft > 0) $this->menu->send($player);
         });
-        $this->menu->readonly();
+        $this->menu->setListener(InvMenu::readonly());
         $this->menu->send($player);
 
         $this->itemsLeft = $crate->getDropCount();

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -19,6 +19,7 @@ use pocketmine\utils\TextFormat;
 class RouletteTask extends Task
 {
     const INVENTORY_ROW_COUNT = 9;
+
     /** @var Player */
     private $player;
     /** @var Crate */
@@ -27,12 +28,14 @@ class RouletteTask extends Task
     private $tile;
     /** @var InvMenu */
     private $menu;
+
     /** @var int */
     private $currentTick = 0;
     /** @var bool */
     private $showReward = false;
     /** @var int */
     private $itemsLeft;
+
     /** @var CrateItem[] */
     private $lastRewards = [];
 

--- a/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
+++ b/src/DaPigGuy/PiggyCrates/tasks/RouletteTask.php
@@ -1,3 +1,4 @@
+
 <?php
 
 declare(strict_types=1);
@@ -9,7 +10,6 @@ use DaPigGuy\PiggyCrates\crates\CrateItem;
 use DaPigGuy\PiggyCrates\PiggyCrates;
 use DaPigGuy\PiggyCrates\tiles\CrateTile;
 use muqsit\invmenu\InvMenu;
-use muqsit\invmenu\SharedInvMenu;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\item\ItemFactory;
 use pocketmine\item\ItemIds;
@@ -20,23 +20,20 @@ use pocketmine\utils\TextFormat;
 class RouletteTask extends Task
 {
     const INVENTORY_ROW_COUNT = 9;
-
     /** @var Player */
     private $player;
     /** @var Crate */
     private $crate;
     /** @var CrateTile */
     private $tile;
-    /** @var SharedInvMenu */
+    /** @var InvMenu */
     private $menu;
-
     /** @var int */
     private $currentTick = 0;
     /** @var bool */
     private $showReward = false;
     /** @var int */
     private $itemsLeft;
-
     /** @var CrateItem[] */
     private $lastRewards = [];
 

--- a/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
+++ b/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
@@ -39,7 +39,7 @@ class CrateTile extends Chest
         parent::__construct($level, $nbt);
         if (($crateType = $this->crateType) === null) return;
         $this->menu = InvMenu::create(count($crateType->getDrops()) > 27 ? InvMenu::TYPE_DOUBLE_CHEST : InvMenu::TYPE_CHEST);
-        $this->menu->readonly();
+        $this->menu->setListener(InvMenu::readonly());
         $this->menu->setName(PiggyCrates::getInstance()->getMessage("crates.menu-name", ["{CRATE}" => $crateType->getName()]));
     }
 

--- a/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
+++ b/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
@@ -25,12 +25,15 @@ class CrateTile extends Chest
     public $crateName;
     /** @var Crate|null */
     public $crateType;
+
     /** @var bool */
     public $isOpen = false;
     /** @var Player|null */
     public $currentPlayer;
+
     /** @var array[] */
     public $floatingTextParticles = [];
+
     /** @var InvMenu */
     private $menu;
 

--- a/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
+++ b/src/DaPigGuy/PiggyCrates/tiles/CrateTile.php
@@ -9,7 +9,6 @@ use DaPigGuy\PiggyCrates\crates\CrateItem;
 use DaPigGuy\PiggyCrates\PiggyCrates;
 use DaPigGuy\PiggyCrates\tasks\RouletteTask;
 use muqsit\invmenu\InvMenu;
-use muqsit\invmenu\SharedInvMenu;
 use pocketmine\command\ConsoleCommandSender;
 use pocketmine\item\Item;
 use pocketmine\level\Level;
@@ -26,16 +25,13 @@ class CrateTile extends Chest
     public $crateName;
     /** @var Crate|null */
     public $crateType;
-
     /** @var bool */
     public $isOpen = false;
     /** @var Player|null */
     public $currentPlayer;
-
     /** @var array[] */
     public $floatingTextParticles = [];
-
-    /** @var SharedInvMenu */
+    /** @var InvMenu */
     private $menu;
 
     public function __construct(Level $level, CompoundTag $nbt)


### PR DESCRIPTION
It's more about how outdated the user's php binaries are (support for php-ds for the stable version was dropped a week ago: https://github.com/pmmp/php-build-scripts/commit/855d00960ebe53fa5c0f71d6cd9b6588c51731cc so update InvMenu it can be a shortcut and fix name of Paroxity

### What does the PR change?
Does your Pull Request:
- resolve a bug? Yes, 
- #96 
- InvMenu https://github.com/Muqsit/InvMenu/commit/af247cf4b5d43b72c5a3fff74d13898bcf118cb1 fixed about php-ds and it's Paroxity without Team 

### Testing Environment
<!-- Use `/version` for PMMP version -->
* PocketMine-MP: 3.21.1
* PHP: 7.4.21