### PR TITLE
Fixed crash when KeyType NBT is missing

### DIFF
--- a/src/DaPigGuy/PiggyCrates/crates/Crate.php
+++ b/src/DaPigGuy/PiggyCrates/crates/Crate.php
@@ -7,6 +7,7 @@ namespace DaPigGuy\PiggyCrates\crates;
 use DaPigGuy\PiggyCrates\PiggyCrates;
 use pocketmine\item\Item;
 use pocketmine\item\ItemFactory;
+use pocketmine\nbt\tag\StringTag;
 use pocketmine\player\Player;
 
 class Crate
@@ -82,6 +83,7 @@ class Crate
     {
         return $item->getId() === (int)$this->plugin->getConfig()->getNested("keys.id") &&
             $item->getMeta() === (int)$this->plugin->getConfig()->getNested("keys.meta") &&
-            $item->getNamedTag()->getString("KeyType") === $this->getName();
+            ($keyTypeTag = $item->getNamedTag()->getTag("KeyType")) instanceof StringTag &&
+            $keyTypeTag->getValue() === $this->getName();
     }
 }


### PR DESCRIPTION
<!-- Failure to complete the required fields will result in the pull request being closed. -->
Please make sure your issue complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title.

### What does the PR change?
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
-->
Fixed a crash when KeyType NBT is missing:
[Sun_Mar_13-18.52.40-UTC_2022.log](https://github.com/DaPigGuy/PiggyCrates/files/8240420/Sun_Mar_13-18.52.40-UTC_2022.log)

### Testing Environment
<!-- Use `/version` for PMMP version -->
* PocketMine-MP: 4.2.0
* PHP: 8.0.12
* Server OS: linux

<!--- Provide any extra information below  -->
### Extra Information
