### PR TITLE
CRATE PREVIEW: Activation and deactivation

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -13,4 +13,6 @@ crates:
     # Minimum speed: speed >= 1
     # If speed ends up being less than 1, then your default speed will be set to 1.
     speed: 2
-preview-crate: true
+    #Crate preview:
+    #Use "true" or "false" to disable or enable this option.
+    preview: true

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -13,3 +13,4 @@ crates:
     # Minimum speed: speed >= 1
     # If speed ends up being less than 1, then your default speed will be set to 1.
     speed: 2
+preview-crate: true

--- a/src/DaPigGuy/PiggyCrates/EventListener.php
+++ b/src/DaPigGuy/PiggyCrates/EventListener.php
@@ -33,7 +33,9 @@ class EventListener implements Listener
                 } elseif ($tile->getCrateType()->isValidKey($item)) {
                     $tile->openCrate($player, $item);
                 } elseif ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
-                    $tile->previewCrate($player);
+                    if (PiggyCrates::getInstance()->getConfig()->get("Preview-crate", true) === true){
+                        $tile->previewCrate($player);
+                    }
                 }
                 $event->cancel();
                 return;

--- a/src/DaPigGuy/PiggyCrates/EventListener.php
+++ b/src/DaPigGuy/PiggyCrates/EventListener.php
@@ -32,10 +32,9 @@ class EventListener implements Listener
                     $player->sendTip($this->plugin->getMessage("crates.error.invalid-crate"));
                 } elseif ($tile->getCrateType()->isValidKey($item)) {
                     $tile->openCrate($player, $item);
-                } elseif ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
-                    if (PiggyCrates::getInstance()->getConfig()->get("preview-crate", true) === true){
-                        $tile->previewCrate($player);
-                    }
+                } elseif (PiggyCrates::getInstance()->getConfig()->getNested("crates.roulette.preview", true)) {
+                    $tile->previewCrate($player);
+                    } elseif ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
                 }
                 $event->cancel();
                 return;

--- a/src/DaPigGuy/PiggyCrates/EventListener.php
+++ b/src/DaPigGuy/PiggyCrates/EventListener.php
@@ -33,7 +33,7 @@ class EventListener implements Listener
                 } elseif ($tile->getCrateType()->isValidKey($item)) {
                     $tile->openCrate($player, $item);
                 } elseif ($event->getAction() === PlayerInteractEvent::RIGHT_CLICK_BLOCK) {
-                    if (PiggyCrates::getInstance()->getConfig()->get("Preview-crate", true) === true){
+                    if (PiggyCrates::getInstance()->getConfig()->get("preview-crate", true) === true){
                         $tile->previewCrate($player);
                     }
                 }


### PR DESCRIPTION
Listo para la revisión: 
```yaml
keys:
         id: 131
         meta: 0
         name: "{CRATE} Key"
         lore: "Claim rewards from a {CRATE} Crate"
     crates:
     # Options: instant, roulette
        mode: roulette
        roulette:
        # Minimum duration: (duration/speed) >= 5.5
        # If (duration/speed) ends up being less than 5.5, then your default time will be set to (6*speed)
        duration: 30
        # Minimum speed: speed >= 1
        # If speed ends up being less than 1, then your default speed will be set to 1.
        speed: 2
        #Crate preview:
        #Use "true" or "false" to disable or enable this option.
        preview: true
    ```